### PR TITLE
Incrustar metadata

### DIFF
--- a/files/config/exiftool_dpcat.config
+++ b/files/config/exiftool_dpcat.config
@@ -1,0 +1,80 @@
+%Image::ExifTool::UserDefined = (
+    'Image::ExifTool::XMP::Main' => {
+        Metadata => {
+            Description => 'Metadata',
+            SubDirectory => {
+                TagTable => 'Image::ExifTool::UserDefined::Metadata',
+            },
+        },
+        MetadataOA => {
+            Description => 'Metadata de Objeto de Aprendizaje',
+            SubDirectory => {
+                TagTable => 'Image::ExifTool::UserDefined::MetadataOA',
+            },
+        },
+        MetadataGen => {
+            Description => 'Metadata de Produccion Generica',
+            SubDirectory => {
+                TagTable => 'Image::ExifTool::UserDefined::MetadataGen',
+            },
+        },
+    },
+);
+
+%Image::ExifTool::UserDefined::Metadata = (
+    GROUPS => { 0 => 'XMP', 1 => 'XMP-Metadata', 2 => 'Other' },
+    NAMESPACE => { 'Metadata' => 'http://www.ull.es/' },
+    WRITABLE => 'string',
+
+    knowledge_areas => { Description => 'Clasificacion Universidad' },
+    title => { Description => 'Titulo completo de la produccion' },
+    creator => { Description => 'Autor/es o creador/es' },
+    keyword => { Description => 'Palabras clave o etiquetas' },
+    description => { Description => 'Descripcion breve' },
+    license => { Description => 'Licencia de uso' },
+);
+
+%Image::ExifTool::UserDefined::MetadataOA = (
+    GROUPS => { 0 => 'XMP', 1 => 'XMP-MetadataOA', 2 => 'Other' },
+    NAMESPACE => { 'MetadataOA' => 'http://www.ull.es/' },
+    WRITABLE => 'string',
+
+    guideline => { Description => 'Area de conocimiento UNESCO' },
+    contributor => { Description => 'Colaborador/es' },
+    audience => { Description => 'Audiencia o publico objetivo' },
+    typical_age_range => { Description => 'Edad de la audiencia o publico objetivo' },
+    source => { Description => 'Identificador de obra derivada' },
+    language => { Description => 'Spanish' },
+    ispartof => { Description => 'Serie a la que pertence' },
+    location => { Description => 'Localizacion' },
+    venue => { Description => 'Lugar de celebracion' },
+    temporal => { Description => 'Intervalo de tiempo' },
+    rightsholder => { Description => 'Persona, entidad u organizacion responsable de la gestion de los derechos de autor' },
+    date => { Description => 'Fecha de grabacion' },
+    created => { Description => 'Fecha de produccion' },
+    valid => { Description => 'Fecha de validacion' },
+    interactivity_type => { Description => 'Tipo de interaccion con la audiencia o publico objetivo' },
+    interactivity_level => { Description => 'Nivel de interaccion' },
+    learning_resource_type => { Description => 'Tipo de recurso educativo' },
+    semantic_density => { Description => 'Densidad semantica del contenido' },
+    context => { Description => 'Contexto educativo' },
+    dificulty => { Description => 'Nivel de dificultad' },
+    typical_learning_time => { Description => 'Tiempo estimado para la adquisicion de conocimientos' },
+    educational_language => { Description => 'Caracteristicas del lenguaje educativo' },
+    purpose => { Description => 'Objetivo del contenido' },
+    unesco => { Description => 'Dominio de conocimiento' },
+);
+
+%Image::ExifTool::UserDefined::MetadataGen = (
+    GROUPS => { 0 => 'XMP', 1 => 'XMP-MetadataGen', 2 => 'Other' },
+    NAMESPACE => { 'MetadataGen' => 'http://www.ull.es/' },
+    WRITABLE => 'string',
+
+    transcription => { Description => 'Transcripcion' },
+    contributor => { Description => 'Colaborador/es' },
+    language => { Description => 'Idioma' },
+    location => { Description => 'Localizacion' },
+    venue => { Description => 'Lugar de celebracion' },
+);
+
+1;  #end

--- a/postproduccion/encoder.py
+++ b/postproduccion/encoder.py
@@ -69,6 +69,20 @@ def x264_presets():
     return " ".join(map(lambda x: "%s=%s" % tuple(x), params))
 
 """
+Incrusta la metadata al video final
+"""
+def embed_metadata(filename, metadata):
+    command = "'%s' -config %s %s '%s'" % (config.get_option('EXIFTOOL_PATH'), config.get_option('EXIFTOOL_CONFIG'), metadata, filename)
+    p = subprocess.Popen(shlex.split(str(command)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
+    out, err = p.communicate() # Esperar a finalizar
+
+    # Borrar video original
+    try:
+        os.unlink(filename + '_original')
+    except:
+        pass
+
+"""
 Realiza el montaje de un video
 """
 def encode_mixed_video(mltfile, outfile, logfile, pid_notifier = None):

--- a/postproduccion/encoder.py
+++ b/postproduccion/encoder.py
@@ -72,6 +72,10 @@ def x264_presets():
 Incrusta la metadata al video final
 """
 def embed_metadata(filename, metadata):
+
+    if not os.path.exists(filename):
+        return False
+
     command = "'%s' -config %s %s '%s'" % (config.get_option('EXIFTOOL_PATH'), config.get_option('EXIFTOOL_CONFIG'), metadata, filename)
     p = subprocess.Popen(shlex.split(str(command)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
     out, err = p.communicate() # Esperar a finalizar
@@ -81,6 +85,8 @@ def embed_metadata(filename, metadata):
         os.unlink(filename + '_original')
     except:
         pass
+
+    return True
 
 """
 Realiza el montaje de un video

--- a/postproduccion/forms.py
+++ b/postproduccion/forms.py
@@ -104,6 +104,7 @@ class ConfigForm(Form):
     melt_path = ExecutableField(label = u'Ruta del \'melt\'')
     avconv_path = ExecutableField(label = u'Ruta del \'avconv\'')
     mp4box_path = ExecutableField(label = u'Ruta del \'MP4Box\'')
+    exiftool_path = ExecutableField(label = u'Ruta del \'exiftool\'')
     crontab_path = ExecutableField(label = u'Ruta del \'crontab\'')
     max_preview_width = forms.IntegerField(label = u'Anchura máxima de la previsualización')
     max_preview_height = forms.IntegerField(label = u'Altura máxima de la previsualización')

--- a/postproduccion/management/commands/incrustar_metadata.py
+++ b/postproduccion/management/commands/incrustar_metadata.py
@@ -1,0 +1,78 @@
+# -*- encoding: utf-8 -*-
+from django.core.management.base import BaseCommand
+from postproduccion.models import Video
+from postproduccion import video
+
+def parse_input(input):
+    
+    if 'all' in input:
+        return Video.objects.all()
+    
+    videos = []
+    
+    for arg in input:
+        if '-' in arg:
+            limits = arg.split('-')
+            try:
+                min_, max_= int(limits[0]), int(limits[-1])
+            except:
+                continue
+            else:
+                if not min_ < max_:
+                    continue
+            for id in xrange(min_, max_):
+                try:
+                    v = Video.objects.get(pk=id)
+                except:
+                    continue
+                videos += [v]
+        else:
+            try:
+                v = Video.objects.get(pk=int(arg))
+            except:
+                continue
+            videos += [v]
+            
+    # Eliminar videos duplicados
+    return sorted(set(videos))
+
+class Command(BaseCommand):
+    help = u'Incrutar metadata en los vídeos'
+
+    def add_arguments(self, parser):
+        # Positional argument
+        parser.add_argument('video_id',
+            metavar='ID',
+            type=str,
+            nargs='+',
+            help=u'Vídeos para incrustar metadata. Ej: 342 465 500-980')
+
+        # Named (optional) arguments
+        parser.add_argument('-a', '--add',
+            action='store_true',
+            dest='add',
+            default=True,
+            help=u'Incrustar metadata en el vídeo')
+
+        parser.add_argument('-s', '--show',
+            action='store_true',
+            dest='show',
+            default=False,
+            help=u'Mostrar metadata del vídeo')            
+
+    def handle(self, *args, **options):
+        
+        if options['show']:
+            options['add'] = False
+            for v in parse_input(options['video_id']):
+                print '\n--->Video [%s]: %s' % (v.id, v)
+                for metadata in video.get_metadata(v).split('-XMP:'):
+                    if metadata:
+                        print metadata
+
+        if options['add']:
+            for v in parse_input(options['video_id']):
+                if video.add_metadata(v) and options['verbosity'] > 1:
+                    print "Video [%s]: updated metadata!" % v.id
+                elif options['verbosity'] > 1:
+                    print "Video [%s]: it was not possible to add metadata..." % v.id

--- a/postproduccion/utils.py
+++ b/postproduccion/utils.py
@@ -10,6 +10,7 @@ import shlex
 import re
 import json
 
+from django.conf import settings
 from configuracion import config
 
 """
@@ -28,6 +29,8 @@ def set_default_settings():
         [ 'MP4BOX_PATH',         which('MP4Box') ],
         [ 'CRONTAB_PATH',        which('crontab') ],
         [ 'MEDIAINFO_PATH',      which('mediainfo') ],
+        [ 'EXIFTOOL_PATH',       which('exiftool') ],
+        [ 'EXIFTOOL_CONFIG',     os.path.join(settings.MEDIA_ROOT, 'config/exiftool_dpcat.config') ],
         [ 'MAX_PREVIEW_WIDTH',   400 ],
         [ 'MAX_PREVIEW_HEIGHT',  300 ],
         [ 'VIDEO_LIBRARY_PATH',  '/home/adminudv/videos/videoteca/' ],
@@ -55,6 +58,15 @@ Normaliza una cadena para generar nombres de fichero seguros.
 """
 def normalize_filename(name):
     return unicodedata.normalize('NFKD', name).encode('ascii','ignore').translate(None, string.punctuation).replace(' ', '_')
+
+"""
+Devuelve una cadena normalizada a partir de una de tipo unicode.
+"""
+def normalize_string(string):
+    try:
+        return unicodedata.normalize('NFKD', string).encode('ascii','ignore')
+    except:
+        return string
 
 """
 Genera un nombre de fichero para un nuevo vídeo
@@ -153,6 +165,19 @@ def mp4box_version():
         data = subprocess.Popen(shlex.split(str(command)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT).communicate()[0]
         try:
             return re.search('version (\S*)', data).group(1)
+        except AttributeError:
+            return None
+
+"""
+Devuelve la versión del exiftool instalado.
+"""
+def exiftool_version():
+    fpath = config.get_option('EXIFTOOL_PATH')
+    if is_exec(fpath):
+        command = "%s -ver" % fpath
+        data = subprocess.Popen(shlex.split(str(command)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT).communicate()[0]
+        try:
+            return re.search('([\.0-9]+)', data).group(1)
         except AttributeError:
             return None
 

--- a/postproduccion/video.py
+++ b/postproduccion/video.py
@@ -96,9 +96,15 @@ def get_metadata(v):
     str_metadata = ''
 
     if v.objecto_aprendizaje:
-        metadata = v.metadataoa
+        try:
+            metadata = v.metadataoa
+        except:
+            return str_metadata
     else:
-        metadata = v.metadatagen
+        try:
+            metadata = v.metadatagen
+        except:
+            return str_metadata
 
     for f in metadata._meta.get_fields():
         try:
@@ -258,7 +264,8 @@ def add_metadata(video):
     # Obtener metadata
     metadata = get_metadata(video)
 
-    # Incrustar metadata
-    embed_metadata(video.fichero, metadata)
+    # Incrustar metadatas
+    if not embed_metadata(video.fichero, metadata):
+        return False
 
     return True

--- a/postproduccion/video.py
+++ b/postproduccion/video.py
@@ -1,6 +1,6 @@
-#encoding: utf-8
+# -*- coding: utf-8 -*-
 from django.shortcuts import render_to_response
-from postproduccion.encoder import get_file_info, encode_mixed_video, encode_preview, get_video_duration, make_streamable
+from postproduccion.encoder import get_file_info, encode_mixed_video, encode_preview, get_video_duration, make_streamable, embed_metadata
 from postproduccion.models import TecData, Previsualizacion
 from configuracion import config
 from postproduccion import utils
@@ -12,6 +12,7 @@ import tempfile
 import shutil
 import string
 from StringIO import StringIO
+import datetime
 
 
 """
@@ -87,6 +88,30 @@ def parse_mediainfo(mediadata):
             mediainfo.append(sect)
     return mediainfo
 
+"""
+Devolver metada del video para incrustarla en el video
+"""
+def get_metadata(v):
+
+    str_metadata = ''
+
+    if v.objecto_aprendizaje:
+        metadata = v.metadataoa
+    else:
+        metadata = v.metadatagen
+
+    for f in metadata._meta.get_fields():
+        try:
+            value = getattr(metadata, 'get_%s_display' % f.name)()
+        except AttributeError:
+            value = getattr(metadata, f.name)
+
+        if value.__class__ == unicode:
+            str_metadata += "-XMP:%s='%s' " % (f.name, utils.normalize_string(value))
+        elif value.__class__ in (str, datetime.datetime):
+            str_metadata += "-XMP:%s='%s' " % (f.name, value)
+
+    return str_metadata
 
 def calculate_preview_size(v):
     [width, height, ratio] = get_tec_data(v.tecdata.xml_data)
@@ -224,4 +249,16 @@ def create_preview(video, logfile, pid_notifier = None):
 
     # Actualiza el estado del vídeo
     video.set_status('PTU')
+    return True
+
+"""
+Añadir toda la metadata al video
+"""
+def add_metadata(video):
+    # Obtener metadata
+    metadata = get_metadata(video)
+
+    # Incrustar metadata
+    embed_metadata(video.fichero, metadata)
+
     return True

--- a/postproduccion/views.py
+++ b/postproduccion/views.py
@@ -624,6 +624,8 @@ def alerts(request):
         lista.append({ 'tipo' : 'ejecutable', 'exe' : 'mediainfo', 'fecha' : datetime.datetime.min })
     if not utils.mp4box_version():
         lista.append({ 'tipo' : 'ejecutable', 'exe' : 'MP4Box', 'fecha' : datetime.datetime.min })
+    if not utils.exiftool_version():
+        lista.append({ 'tipo' : 'ejecutable', 'exe' : 'exiftool', 'fecha' : datetime.datetime.min })
     if not utils.is_exec(config.get_option('CRONTAB_PATH')):
         lista.append({ 'tipo' : 'ejecutable', 'exe' : 'crontab', 'fecha' : datetime.datetime.min })
     # Comprueba las rutas a los directorios.
@@ -675,6 +677,7 @@ def status(request):
     meltver = utils.melt_version()
     mediainfover = utils.mediainfo_version()
     mp4boxver = utils.mp4box_version()
+    exiftoolver = utils.exiftool_version()
     exes = {
         'AVCONV'  : {
             'path'    : config.get_option('AVCONV_PATH'),
@@ -700,6 +703,11 @@ def status(request):
             'path'    : config.get_option('MP4BOX_PATH'),
             'status'  : True if mp4boxver else False,
             'version' : mp4boxver,
+        },
+        'exiftool'    : {
+            'path'    : config.get_option('EXIFTOOL_PATH'),
+            'status'  : True if exiftoolver else False,
+            'version' : exiftoolver,
         },
     }
 

--- a/postproduccion/views.py
+++ b/postproduccion/views.py
@@ -286,6 +286,7 @@ def definir_metadatos_user(request, tk_str):
             token.token_attended(v)
             v.status = 'ACE'
             v.save()
+            video.add_metadata(v)
             return render_to_response("section-resumen-aprobacion.html", { 'v' : v, 'aprobado' : True }, context_instance=RequestContext(request))
 
     else:
@@ -348,6 +349,7 @@ def definir_metadatos_oper(request, video_id):
             m.date = v.informeproduccion.fecha_grabacion
             m.created = v.informeproduccion.fecha_produccion
             m.save()
+            video.add_metadata(v)
             messages.success(request, 'Metadata actualizada')
     else:
         form = MetadataForm(instance = getattr(v, metadataField)) if hasattr(v, metadataField) else MetadataForm(initial = initial_data)


### PR DESCRIPTION
Incrustar en los vídeos la metadata que se tiene sobre ellos.

Hay que tener en cuenta que para ello se utiliza una nueva herramienta ("Exiftool") que permite visualizar y añadir nueva metadata. Para instalarla en *buntus y derivados:

`sudo apt-get install libimage-exiftool-perl`
